### PR TITLE
refactor: Use release-it's default publish path

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -1,7 +1,4 @@
 {
-  "npm": {
-    "publishPath": "./dist"
-  },
   "git": {
     "commitMessage": "chore: Release v${version}"
   },


### PR DESCRIPTION
This PR deletes the [`npm.publishPath`](https://github.com/release-it/release-it/blob/HEAD/docs/npm.md#publish-path) field.