### PR TITLE
fix: Change image container's margin-bottom specificity

### DIFF
--- a/src/ImageGalleryStyles.ts
+++ b/src/ImageGalleryStyles.ts
@@ -10,8 +10,8 @@ export class ImageGalleryStyles {
       columnGap: `${gapSize}px`,
     };
     this.imageContainerStyle = {
-      marginBottom: `${gapSize}px`,
       margin: 0,
+      marginBottom: `${gapSize}px`,
       position: "relative",
     };
     this.imageStyle = {


### PR DESCRIPTION
This PR gives `margin-bottom` higher specificity over the `margin` property.