### PR TITLE
docs: Add references to the documentation on this keyword's types

### DIFF
--- a/src/ImageGalleryStyles.ts
+++ b/src/ImageGalleryStyles.ts
@@ -35,3 +35,7 @@ export class ImageGalleryStyles {
     };
   }
 }
+
+// Ref:
+// - https://www.typescriptlang.org/docs/handbook/2/classes.html#this-types
+// - https://www.typescriptlang.org/docs/handbook/2/functions.html#declaring-this-in-a-function


### PR DESCRIPTION
This PR references the TypeScript doc on the `this` keyword types.