### PR TITLE
refactor: Use ref to manipulate lightbox

### DIFF
--- a/src/ImageGallery.tsx
+++ b/src/ImageGallery.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useEffect, useState } from "react";
+import React, { ReactElement, useEffect, useRef, useState } from "react";
 import { ImageGalleryPropsType } from "./ImageGallery.types";
 import { imageGalleryStyles } from "./imageGalleryStyles";
 
@@ -13,6 +13,7 @@ export function ImageGallery({
   const [fullscreen, setFullscreen] = useState(false);
   const [imageSrc, setImageSrc] = useState("");
   const [slideNumber, setSlideNumber] = useState(1);
+  const lightboxRef = useRef<HTMLElement>(null);
 
   const galleryContainerStyle = imageGalleryStyles(
     columnCount,
@@ -67,7 +68,7 @@ export function ImageGallery({
 
   const lightBoxElement = (
     <article
-      id="codesweetly-lightbox"
+      ref={lightboxRef}
       style={modalContainerStyle}
       tabIndex={-1}
       onKeyDown={(e) => handleKeyDownOnModal(e)}
@@ -233,8 +234,7 @@ export function ImageGallery({
   useEffect(() => {
     if (showModal) {
       document.documentElement.style.overflow = "hidden";
-      const modal = document.getElementById("codesweetly-lightbox");
-      modal?.focus();
+      lightboxRef.current?.focus();
     } else {
       document.documentElement.style.overflow = "";
       document.fullscreenElement &&
@@ -244,30 +244,29 @@ export function ImageGallery({
 
   useEffect(() => {
     if (fullscreen) {
-      const modal = document.getElementById("codesweetly-lightbox");
-      modal?.requestFullscreen().catch((error) => {
+      lightboxRef.current?.requestFullscreen().catch((error) => {
         alert(
           `Error while attempting to switch into fullscreen mode: ${error.message} (${error.name})`
         );
       });
-      modal?.focus();
+      lightboxRef.current?.focus();
     }
     if (document.fullscreenElement) {
       document.exitFullscreen().catch((error) => console.error(error));
-      const modal = document.getElementById("codesweetly-lightbox");
-      modal?.focus();
+      lightboxRef.current?.focus();
     }
   }, [fullscreen]);
 
   useEffect(() => {
-    const modal = document.getElementById("codesweetly-lightbox");
     function handleFullscreenchange() {
       if (!document.fullscreenElement && fullscreen) {
         setFullscreen(false);
       }
     }
-    modal?.addEventListener("fullscreenchange", () => handleFullscreenchange());
-    return modal?.removeEventListener("fullscreenchange", () =>
+    lightboxRef.current?.addEventListener("fullscreenchange", () =>
+      handleFullscreenchange()
+    );
+    return lightboxRef.current?.removeEventListener("fullscreenchange", () =>
       handleFullscreenchange()
     );
   }, [fullscreen]);

--- a/src/ImageGallery.tsx
+++ b/src/ImageGallery.tsx
@@ -8,12 +8,12 @@ export function ImageGallery({
   columnWidth = 230,
   gapSize = 24,
 }: ImageGalleryPropsType) {
-  const [showModal, setShowModal] = useState(false);
   const [showModalControls, setShowModalControls] = useState(false);
   const [fullscreen, setFullscreen] = useState(false);
   const [imageSrc, setImageSrc] = useState("");
   const [slideNumber, setSlideNumber] = useState(1);
   const lightboxRef = useRef<HTMLElement>(null);
+  const showModal = useRef(false);
 
   const galleryContainerStyle = imageGalleryStyles(
     columnCount,
@@ -31,7 +31,7 @@ export function ImageGallery({
     undefined,
     undefined,
     undefined,
-    showModal
+    showModal.current
   ).modalContainerStyle;
   const modalSlideNumberStyle = imageGalleryStyles().modalSlideNumberStyle;
   const modalToolbarStyle = imageGalleryStyles().modalToolbarStyle;
@@ -75,7 +75,7 @@ export function ImageGallery({
       onMouseEnter={() => setShowModalControls(true)}
       onMouseLeave={() => setShowModalControls(false)}
       onClick={(e) =>
-        (e.target as HTMLElement).tagName === "SECTION" && setShowModal(false)
+        (e.target as HTMLElement).tagName === "SECTION" && showLightbox(false)
       }
     >
       <span
@@ -123,7 +123,7 @@ export function ImageGallery({
           aria-label="Close lightbox"
           style={modalToolbarBtnStyle}
           title="Close lightbox"
-          onClick={() => setShowModal(false)}
+          onClick={() => showLightbox(false)}
         >
           {SvgElement(
             <path d="M2.146 2.854a.5.5 0 1 1 .708-.708L8 7.293l5.146-5.147a.5.5 0 0 1 .708.708L8.707 8l5.147 5.146a.5.5 0 0 1-.708.708L8 8.707l-5.146 5.147a.5.5 0 0 1-.708-.708L7.293 8z" />
@@ -191,7 +191,7 @@ export function ImageGallery({
   }
 
   function openLightboxOnSlide(imgSrc: string, number: number) {
-    setShowModal(true);
+    showLightbox(true);
     setImageSrc(imgSrc);
     setSlideNumber(number);
   }
@@ -199,7 +199,7 @@ export function ImageGallery({
   function handleKeyDownOnModal(e: React.KeyboardEvent<HTMLElement>) {
     e.key === "ArrowLeft" && changeSlide(-1);
     e.key === "ArrowRight" && changeSlide(1);
-    e.key === "Escape" && setShowModal(false);
+    e.key === "Escape" && showLightbox(false);
     e.key === "f" && fullscreen && setFullscreen(false);
     e.key === "f" && !fullscreen && setFullscreen(true);
   }
@@ -231,16 +231,18 @@ export function ImageGallery({
     );
   }
 
-  useEffect(() => {
-    if (showModal) {
+  function showLightbox(open: boolean) {
+    if (open) {
       document.documentElement.style.overflow = "hidden";
       lightboxRef.current?.focus();
+      showModal.current = true;
     } else {
       document.documentElement.style.overflow = "";
       document.fullscreenElement &&
         document.exitFullscreen().catch((error) => console.error(error));
+      showModal.current = false;
     }
-  }, [showModal]);
+  }
 
   useEffect(() => {
     if (fullscreen) {

--- a/src/ImageGallery.tsx
+++ b/src/ImageGallery.tsx
@@ -13,7 +13,7 @@ export function ImageGallery({
   const [imageSrc, setImageSrc] = useState("");
   const [slideNumber, setSlideNumber] = useState(1);
   const lightboxRef = useRef<HTMLElement>(null);
-  const showModal = useRef(false);
+  const showLightBox = useRef(false);
 
   const galleryContainerStyle = imageGalleryStyles(
     columnCount,
@@ -31,7 +31,7 @@ export function ImageGallery({
     undefined,
     undefined,
     undefined,
-    showModal.current
+    showLightBox.current
   ).modalContainerStyle;
   const modalSlideNumberStyle = imageGalleryStyles().modalSlideNumberStyle;
   const modalToolbarStyle = imageGalleryStyles().modalToolbarStyle;
@@ -235,12 +235,12 @@ export function ImageGallery({
     if (open) {
       document.documentElement.style.overflow = "hidden";
       lightboxRef.current?.focus();
-      showModal.current = true;
+      showLightBox.current = true;
     } else {
       document.documentElement.style.overflow = "";
       document.fullscreenElement &&
         document.exitFullscreen().catch((error) => console.error(error));
-      showModal.current = false;
+      showLightBox.current = false;
     }
   }
 

--- a/src/ImageGalleryStyles.ts
+++ b/src/ImageGalleryStyles.ts
@@ -2,7 +2,7 @@ export function imageGalleryStyles(
   columnCount?: string | number,
   columnWidth?: string | number,
   gapSize?: number,
-  showModal?: boolean
+  showLightBox?: boolean
 ) {
   const galleryContainerStyle: React.CSSProperties = {
     columnCount,
@@ -36,7 +36,7 @@ export function imageGalleryStyles(
   const modalContainerStyle: React.CSSProperties = {
     outline: "none",
     position: "fixed",
-    display: `${showModal ? "block" : "none"}`,
+    display: `${showLightBox ? "block" : "none"}`,
     zIndex: 7000000000,
     top: 0,
     left: 0,


### PR DESCRIPTION
Use [ref](https://react.dev/learn/manipulating-the-dom-with-refs) to access the lightbox element instead of the `getElementById` web API. This eliminates the need to use the state and effect hooks to show or hide the modal.