### PR TITLE
ci: Enable commit grouping explicitly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0 # Fetch all history for all branches and tags (required to allow semantic-release to analyze commits)
           persist-credentials: false # Explicitly disable the token persistence
 
-      # Authenticate git with the GitHub App token for pushing changelog and version bump commits back to the repository
+      # Reconfigure git remote URL to use the GitHub App token for authentication instead of the default GITHUB_TOKEN
       - name: Authenticate git with GitHub App token
         run: |
           git remote set-url origin \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0 # Fetch all history for all branches and tags (required to allow semantic-release to analyze commits)
           persist-credentials: false # Explicitly disable the token persistence
 
-      # Reconfigure git remote URL to use the GitHub App token for authentication instead of the default GITHUB_TOKEN
+      # Reconfigure git remote URL to use the GitHub App token for authentication instead of the default GITHUB_TOKEN for pushing changes back to the repository by semantic-release
       - name: Authenticate git with GitHub App token
         run: |
           git remote set-url origin \

--- a/.releaserc.mjs
+++ b/.releaserc.mjs
@@ -41,6 +41,8 @@ export default {
           ],
         },
         writerOpts: {
+          groupBy: "type", // 🔑 THIS enables grouping
+          commitGroupsSort: "title", // Sort sections
           commitsSort: ["scope", "subject"],
         },
       },
@@ -52,6 +54,10 @@ export default {
         changelogFile: "CHANGELOG.md",
         changelogTitle:
           "# 📦 Changelog\n\nAll notable changes to **react-image-grid-gallery** are documented here.\n",
+        writerOpts: {
+          groupBy: "type", // 🔑 Required here too
+          commitGroupsSort: "title",
+        },
       },
     ],
     // 4. Update version + publish to npm


### PR DESCRIPTION
This PR adds grouping rules to the writer to ensure semantic-release groups commits in release notes and changelog files.