### PR TITLE
chore: Run script to remove dist folder only in development

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "author": "Oluwatobi Sofela <contact@codesweetly.com> (https://www.codesweetly.com)",
   "license": "MIT",
   "scripts": {
-    "build": "rm -r dist && npm run build:esm && npm run build:cjs",
+    "dev": "rm -r dist && npm run build",
+    "build": "npm run build:esm && npm run build:cjs",
     "build:esm": "tsc -p tsconfig.esm.json",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "test": "jest --config jest.config.cjs",


### PR DESCRIPTION
This PR ensures that the script to remove the `dist` folder runs only in development, not during the production build.