### PR TITLE
fix: Ignore merge commits entirely to avoid breaking the grouping work

### DIFF
--- a/.releaserc.mjs
+++ b/.releaserc.mjs
@@ -40,6 +40,10 @@ export default {
             { type: "style", section: "🎨 Code Style" },
           ],
         },
+        parserOpts: {
+          mergePattern: "^Merge pull request",
+          mergeCorrespondence: null,
+        },
         writerOpts: {
           groupBy: "type",
           commitGroupsSort: "title",


### PR DESCRIPTION
This PR makes the parser ignore merging commits to ensure the grouping works.