### PR TITLE
fix: Make ESM build emit imports with extensions

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -10,4 +10,8 @@ module.exports = {
       },
     ],
   },
+  // Resolve .js imports to .ts/.tsx files for testing (for example, ImageGalleryStyles.js -> ImageGalleryStyles.ts)
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+  },
 };

--- a/src/ImageGallery.tsx
+++ b/src/ImageGallery.tsx
@@ -1,7 +1,10 @@
 import { ReactElement, useRef, useState, useEffect } from "react";
 import { flushSync } from "react-dom";
-import { ImageGalleryPropsType, ImgSrcInfoType } from "./ImageGallery.types";
-import { imageGalleryStyles } from "./ImageGalleryStyles";
+import {
+  ImageGalleryPropsType,
+  ImgSrcInfoType,
+} from "./ImageGallery.types.jsx";
+import { imageGalleryStyles } from "./ImageGalleryStyles.js"; // .js extension is required for ESM build import resolution
 
 export function ImageGallery({
   imagesInfoArray,

--- a/src/ImageGalleryStyles.ts
+++ b/src/ImageGalleryStyles.ts
@@ -1,10 +1,10 @@
-import { ImageGalleryStylesType } from "./ImageGallery.types";
+import { ImageGalleryStylesType } from "./ImageGallery.types.jsx"; // .jsx extension is required for ESM build import resolution
 
 export function imageGalleryStyles(
   columnCount?: string | number,
   columnWidth?: string | number,
   gapSize?: number,
-  fixedCaption?: boolean
+  fixedCaption?: boolean,
 ): ImageGalleryStylesType {
   const modalThumbnailSectionHeight = "20vh";
   const galleryContainerStyle: React.CSSProperties = {


### PR DESCRIPTION
This PR makes the ESM build emit import statements with extensions to resolve the `Gets ReferenceError: exports is not defined` error.