### PR TITLE
ci: Add step to install the Conventional Commits preset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,15 +45,17 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       # Install semantic-release plugins to determine the next version, update changelog, publish to npm, and create GitHub release
-      # - semantic-release@25: The main semantic-release package
-      # - @semantic-release/changelog@6: Update the changelog file
-      # - @semantic-release/git@10: Commit changelog and version bump
+      # - semantic-release: The main semantic-release package
+      # - @semantic-release/changelog: Update the changelog file
+      # - @semantic-release/git: Commit changelog and version bump
+      # - conventional-changelog-conventionalcommits: Conventional Commits preset for changelog generation
       - name: Install semantic-release (CI-only)
         run: |
           npm install --no-save \
             semantic-release@25 \
             @semantic-release/changelog@6 \
             @semantic-release/git@10 \
+            conventional-changelog-conventionalcommits@9 \
 
       # Run semantic-release to automate the release process
       - name: Run semantic-release


### PR DESCRIPTION
This PR adds the step to install the conventional Commits preset for changelog generation. This step is required for the `conventionalcommits` preset to work.