### PR TITLE
chore: Remove redundant JSX option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "husky": "^9.1.7",
         "jest": "^30.2.0",
         "jest-environment-jsdom": "^30.2.0",
-        "react": "^19.0.0",
+        "react": "^19.2.3",
         "ts-jest": "^29.2.5",
         "typescript": "^5.7.3"
       },

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "husky": "^9.1.7",
     "jest": "^30.2.0",
     "jest-environment-jsdom": "^30.2.0",
-    "react": "^19.0.0",
+    "react": "^19.2.3",
     "ts-jest": "^29.2.5",
     "typescript": "^5.7.3"
   },

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "module": "commonjs",
     "moduleResolution": "node10",
-    "noEmit": true,
-    "jsx": "react-jsx"
+    "noEmit": true
   }
 }


### PR DESCRIPTION
This PR removes the redundant `jsx` compiler option.